### PR TITLE
Add device software management module

### DIFF
--- a/app1.0/app/Database.php
+++ b/app1.0/app/Database.php
@@ -36,6 +36,11 @@ class Database
         if ($shouldEnsureBackupsTable) {
             $this->ensureBackupsTable();
         }
+
+        $shouldEnsureSoftwareTable = $config['ensure_device_software_table'] ?? true;
+        if ($shouldEnsureSoftwareTable) {
+            $this->ensureDeviceSoftwareTable();
+        }
     }
 
     public function pdo(): PDO
@@ -67,6 +72,28 @@ SQL;
             $this->pdo->exec($sql);
         } catch (PDOException $exception) {
             throw new PDOException('Unable to ensure the backups table exists: ' . $exception->getMessage(), (int) $exception->getCode(), $exception);
+        }
+    }
+
+    public function ensureDeviceSoftwareTable(): void
+    {
+        $sql = <<<'SQL'
+CREATE TABLE IF NOT EXISTS `device_software` (
+    `id` INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `dm_type` VARCHAR(50) NOT NULL,
+    `dm_model` VARCHAR(100) NOT NULL,
+    `version` VARCHAR(100) NOT NULL,
+    `description` TEXT NULL,
+    `file_name` VARCHAR(255) NOT NULL,
+    `file_type` VARCHAR(255) NULL,
+    `added_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+
+        try {
+            $this->pdo->exec($sql);
+        } catch (PDOException $exception) {
+            throw new PDOException('Unable to ensure the device_software table exists: ' . $exception->getMessage(), (int) $exception->getCode(), $exception);
         }
     }
 }

--- a/app1.0/assets/css/styles.css
+++ b/app1.0/assets/css/styles.css
@@ -496,6 +496,142 @@ table td {
     margin-top: auto;
 }
 
+.software-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.software-card-form {
+    margin-bottom: 0;
+}
+
+.software-form .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.5rem;
+}
+
+.software-form .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.software-form .form-field label {
+    font-weight: 600;
+}
+
+.software-form textarea {
+    min-height: 120px;
+}
+
+.software-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.software-filters .filter-field {
+    flex: 1 1 220px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.software-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.software-card {
+    background-color: var(--card-background);
+    border: 1px solid rgba(30, 64, 175, 0.08);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 12px 30px rgba(30, 64, 175, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.software-card__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.software-card__header h3 {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.software-card__type {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background-color: rgba(59, 130, 246, 0.15);
+    color: var(--primary-dark);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.software-card__meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.software-card__meta div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.software-card__meta dt {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    color: var(--muted-text);
+    margin: 0;
+}
+
+.software-card__meta dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.software-card__description {
+    margin: 0;
+    color: var(--muted-text);
+    line-height: 1.55;
+}
+
+.software-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.software-card__actions form {
+    margin: 0;
+}
+
+.software-card__actions .button-link {
+    flex: 1 1 auto;
+}
+
+.empty-state {
+    text-align: center;
+    color: var(--muted-text);
+    padding: 2rem 0;
+}
+
 @media (max-width: 720px) {
     .card {
         padding: 1.25rem;
@@ -516,6 +652,11 @@ table td {
     }
 
     .table-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .software-card__actions {
         flex-direction: column;
         align-items: stretch;
     }

--- a/app1.0/config.example.php
+++ b/app1.0/config.example.php
@@ -6,6 +6,8 @@ return [
         'username' => 'root',
         'password' => '',
         'charset' => 'utf8mb4',
+        'ensure_backups_table' => true,
+        'ensure_device_software_table' => true,
     ],
     'stock_database' => [
         'host' => '127.0.0.1',
@@ -14,6 +16,7 @@ return [
         'password' => '',
         'charset' => 'utf8mb4',
         'ensure_backups_table' => false,
+        'ensure_device_software_table' => false,
     ],
     'ftp' => [
         'host' => '127.0.0.1',
@@ -22,6 +25,7 @@ return [
         'port' => 21,
         'timeout' => 90,
         'base_path' => '/backups',
+        'software_base_path' => '/logiciels',
         'passive' => true,
     ],
 ];

--- a/app1.0/config.php
+++ b/app1.0/config.php
@@ -6,6 +6,8 @@ return [
         'username' => 'root',
         'password' => '',
         'charset' => 'utf8mb4',
+        'ensure_backups_table' => true,
+        'ensure_device_software_table' => true,
     ],
     'stock_database' => [
         'host' => 'localhost',
@@ -14,6 +16,7 @@ return [
         'password' => '',
         'charset' => 'utf8mb4',
         'ensure_backups_table' => false,
+        'ensure_device_software_table' => false,
     ],
     'ftp' => [
         'host' => '127.0.0.1',   // since XAMPP + FileZilla are on same PC
@@ -22,6 +25,7 @@ return [
         'port' => 21,            // FTP runs here (not 14147!)
         'timeout' => 90,
         'base_path' => '/',      // because home dir = C:\Backupsdm
+        'software_base_path' => '/logiciels',
         'passive' => true,
     ],
 ];

--- a/app1.0/database/device_software.sql
+++ b/app1.0/database/device_software.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `device_software` (
+    `id` INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `dm_type` VARCHAR(50) NOT NULL,
+    `dm_model` VARCHAR(100) NOT NULL,
+    `version` VARCHAR(100) NOT NULL,
+    `description` TEXT NULL,
+    `file_name` VARCHAR(255) NOT NULL,
+    `file_type` VARCHAR(255) DEFAULT NULL,
+    `added_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/app1.0/download_software.php
+++ b/app1.0/download_software.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    header('Location: login.php');
+    exit();
+}
+
+require __DIR__ . '/bootstrap.php';
+
+use App\Database;
+use App\FtpClient;
+
+$softwareId = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if (!$softwareId) {
+    http_response_code(400);
+    echo 'Identifiant de logiciel invalide.';
+    exit();
+}
+
+try {
+    $database = new Database($config['database']);
+    $pdo = $database->pdo();
+} catch (\PDOException $exception) {
+    http_response_code(500);
+    echo 'Impossible de se connecter à la base de données.';
+    exit();
+}
+
+$statement = $pdo->prepare('SELECT file_name, file_type FROM device_software WHERE id = :id');
+$statement->execute([':id' => $softwareId]);
+$software = $statement->fetch();
+
+if (!$software) {
+    http_response_code(404);
+    echo 'Logiciel introuvable.';
+    exit();
+}
+
+$fileName = $software['file_name'] ?? '';
+if ($fileName === '') {
+    http_response_code(404);
+    echo 'Fichier logiciel introuvable.';
+    exit();
+}
+
+$ftpConfig = $config['ftp'];
+$softwareBasePath = trim((string) ($ftpConfig['software_base_path'] ?? ''));
+if ($softwareBasePath !== '') {
+    $ftpConfig['base_path'] = $softwareBasePath;
+}
+
+$ftpClient = new FtpClient($ftpConfig);
+$tempFile = tempnam(sys_get_temp_dir(), 'software_');
+
+try {
+    if (!$ftpClient->download($fileName, $tempFile)) {
+        throw new \RuntimeException('Le fichier n\'a pas pu être téléchargé depuis le serveur FTP.');
+    }
+} catch (\RuntimeException $exception) {
+    http_response_code(500);
+    echo 'Erreur lors de la récupération du fichier logiciel.';
+    $ftpClient->disconnect();
+    @unlink($tempFile);
+    exit();
+}
+
+$downloadName = basename($fileName);
+$mimeType = !empty($software['file_type']) ? $software['file_type'] : 'application/octet-stream';
+
+header('Content-Description: File Transfer');
+header('Content-Type: ' . $mimeType);
+header('Content-Disposition: attachment; filename="' . $downloadName . '"');
+header('Content-Length: ' . filesize($tempFile));
+header('Cache-Control: must-revalidate');
+header('Pragma: public');
+
+readfile($tempFile);
+
+$ftpClient->disconnect();
+@unlink($tempFile);
+exit();

--- a/app1.0/gestion_stock/connexion.php
+++ b/app1.0/gestion_stock/connexion.php
@@ -7,6 +7,7 @@ use App\Database;
 
 $stockConfig = $config['stock_database'] ?? $config['database'];
 $stockConfig['ensure_backups_table'] = $stockConfig['ensure_backups_table'] ?? false;
+$stockConfig['ensure_device_software_table'] = $stockConfig['ensure_device_software_table'] ?? false;
 
 try {
     $stockDatabase = new Database($stockConfig);

--- a/app1.0/logiciels.php
+++ b/app1.0/logiciels.php
@@ -1,0 +1,415 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    header('Location: login.php');
+    exit();
+}
+
+$userRole = $_SESSION['role'] ?? 'user';
+$isAdmin = $userRole === 'admin';
+
+require __DIR__ . '/bootstrap.php';
+
+use App\Database;
+use App\FtpClient;
+
+$db = new Database($config['database']);
+$pdo = $db->pdo();
+$baseUrl = '.';
+
+$catalogue = [
+    'Numériseur' => ['CR CLASSIC', 'CR VITA', 'CR VITAFLEX'],
+    'Capteur' => ['LUX FOCUS', 'DRXPLUS'],
+    'Reprograph' => ['DV5700', 'DV5950', 'DV6950'],
+];
+
+$dmTypes = array_keys($catalogue);
+
+function e(?string $value): string
+{
+    return htmlspecialchars((string) ($value ?? ''), ENT_QUOTES, 'UTF-8');
+}
+
+$errors = [];
+$successMessage = $_SESSION['software_success'] ?? null;
+if ($successMessage !== null) {
+    unset($_SESSION['software_success']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? 'create';
+
+    if ($action === 'delete') {
+        if (!$isAdmin) {
+            $errors[] = 'Vous n\'êtes pas autorisé à supprimer des logiciels.';
+        } else {
+            $softwareId = filter_input(INPUT_POST, 'software_id', FILTER_VALIDATE_INT);
+            if (!$softwareId) {
+                $errors[] = 'Le logiciel à supprimer est invalide.';
+            } else {
+                $statement = $pdo->prepare('SELECT file_name FROM device_software WHERE id = :id');
+                $statement->execute([':id' => $softwareId]);
+                $software = $statement->fetch();
+
+                if (!$software) {
+                    $errors[] = 'Le logiciel demandé est introuvable.';
+                } else {
+                    $ftpConfig = $config['ftp'];
+                    $softwareBasePath = trim((string) ($ftpConfig['software_base_path'] ?? ''));
+                    if ($softwareBasePath !== '') {
+                        $ftpConfig['base_path'] = $softwareBasePath;
+                    }
+
+                    $ftpClient = new FtpClient($ftpConfig);
+                    $fileDeletionIssue = false;
+
+                    try {
+                        if (!empty($software['file_name'])) {
+                            if (!$ftpClient->delete($software['file_name'])) {
+                                $fileDeletionIssue = true;
+                            }
+                        }
+                    } catch (\RuntimeException $exception) {
+                        $fileDeletionIssue = true;
+                    } finally {
+                        $ftpClient->disconnect();
+                    }
+
+                    try {
+                        $deleteStatement = $pdo->prepare('DELETE FROM device_software WHERE id = :id');
+                        $deleteStatement->execute([':id' => $softwareId]);
+
+                        $_SESSION['software_success'] = $fileDeletionIssue
+                            ? 'La fiche a été supprimée, mais le fichier n\'a pas pu être retiré du serveur FTP.'
+                            : 'Le logiciel a été supprimé avec succès.';
+
+                        header('Location: ' . $_SERVER['PHP_SELF']);
+                        exit();
+                    } catch (\PDOException $exception) {
+                        $errors[] = 'Une erreur de base de données est survenue lors de la suppression du logiciel.';
+                    }
+                }
+            }
+        }
+    } else {
+        if (!$isAdmin) {
+            $errors[] = 'Vous n\'êtes pas autorisé à ajouter des logiciels.';
+        } else {
+            $dmType = trim($_POST['dm_type'] ?? '');
+            $dmModel = trim($_POST['dm_model'] ?? '');
+            $version = trim($_POST['version'] ?? '');
+            $description = trim($_POST['description'] ?? '');
+
+            if (!in_array($dmType, $dmTypes, true)) {
+                $errors[] = 'Le type de dispositif médical sélectionné est invalide.';
+            }
+
+            if ($dmType !== '' && (!isset($catalogue[$dmType]) || !in_array($dmModel, $catalogue[$dmType], true))) {
+                $errors[] = 'Le modèle sélectionné ne correspond pas au type de dispositif.';
+            }
+
+            if ($version === '') {
+                $errors[] = 'La version du logiciel est obligatoire.';
+            }
+
+            $fileInfo = $_FILES['software_file'] ?? null;
+            $remoteFilename = '';
+            $remoteFileType = 'application/octet-stream';
+
+            if (!$fileInfo || $fileInfo['error'] === UPLOAD_ERR_NO_FILE) {
+                $errors[] = 'Vous devez sélectionner un fichier logiciel à téléverser.';
+            } elseif ($fileInfo['error'] !== UPLOAD_ERR_OK) {
+                $errors[] = 'Une erreur est survenue lors du téléversement du fichier.';
+            } else {
+                $originalName = $fileInfo['name'] ?? 'logiciel';
+                $safeName = preg_replace('/[^A-Za-z0-9_.-]/', '_', strtolower($originalName));
+                if ($safeName === '' || $safeName === false) {
+                    $safeName = 'logiciel';
+                }
+
+                $remoteFilename = date('Ymd_His') . '_' . $safeName;
+                $remoteFileType = $fileInfo['type'] ?? 'application/octet-stream';
+
+                $ftpConfig = $config['ftp'];
+                $softwareBasePath = trim((string) ($ftpConfig['software_base_path'] ?? ''));
+                if ($softwareBasePath !== '') {
+                    $ftpConfig['base_path'] = $softwareBasePath;
+                }
+
+                $ftpClient = new FtpClient($ftpConfig);
+                $uploadSuccess = false;
+
+                try {
+                    $uploadSuccess = $ftpClient->upload($fileInfo['tmp_name'], $remoteFilename);
+                } catch (\RuntimeException $exception) {
+                    $errors[] = 'Erreur FTP : ' . $exception->getMessage();
+                } finally {
+                    $ftpClient->disconnect();
+                }
+
+                if (!$uploadSuccess) {
+                    $errors[] = 'Impossible de téléverser le fichier sur le serveur FTP.';
+                }
+            }
+
+            if (empty($errors)) {
+                try {
+                    $insertStatement = $pdo->prepare(
+                        'INSERT INTO device_software (dm_type, dm_model, version, description, file_name, file_type, added_at) '
+                        . 'VALUES (:dm_type, :dm_model, :version, :description, :file_name, :file_type, NOW())'
+                    );
+
+                    $insertStatement->execute([
+                        ':dm_type' => $dmType,
+                        ':dm_model' => $dmModel,
+                        ':version' => $version,
+                        ':description' => $description !== '' ? $description : null,
+                        ':file_name' => $remoteFilename,
+                        ':file_type' => $remoteFileType,
+                    ]);
+
+                    $_SESSION['software_success'] = 'Le logiciel a été enregistré avec succès.';
+                    header('Location: ' . $_SERVER['PHP_SELF']);
+                    exit();
+                } catch (\PDOException $exception) {
+                    $errors[] = 'Une erreur de base de données est survenue lors de l\'enregistrement du logiciel.';
+
+                    if ($remoteFilename !== '') {
+                        $ftpConfig = $config['ftp'];
+                        $softwareBasePath = trim((string) ($ftpConfig['software_base_path'] ?? ''));
+                        if ($softwareBasePath !== '') {
+                            $ftpConfig['base_path'] = $softwareBasePath;
+                        }
+
+                        $cleanupClient = new FtpClient($ftpConfig);
+                        try {
+                            $cleanupClient->delete($remoteFilename);
+                        } catch (\RuntimeException $cleanupException) {
+                            // Ignorer les erreurs lors du nettoyage
+                        } finally {
+                            $cleanupClient->disconnect();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+$softwareStatement = $pdo->query('SELECT id, dm_type, dm_model, version, description, file_name, file_type, added_at FROM device_software ORDER BY dm_type ASC, dm_model ASC, added_at DESC');
+$softwareEntries = $softwareStatement->fetchAll();
+$catalogueJson = json_encode($catalogue, JSON_UNESCAPED_UNICODE);
+if ($catalogueJson === false) {
+    $catalogueJson = '{}';
+}
+
+?><!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Logiciels des dispositifs médicaux</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+<?php require __DIR__ . '/partials/top_nav.php'; ?>
+<header class="page-header">
+    <img src="assets/images/logo.png" alt="Logo IMAlliance" class="page-logo">
+    <div class="page-header-content">
+        <h1>Logiciels des dispositifs médicaux</h1>
+        <p>Retrouvez les logiciels officiels pour chaque dispositif médical et téléchargez-les en un clic.</p>
+    </div>
+</header>
+
+<main class="software-layout">
+    <?php if (!empty($successMessage)): ?>
+        <div class="alert alert-success">
+            <?= e($successMessage); ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)): ?>
+        <div class="alert alert-error">
+            <h2>Veuillez corriger les éléments suivants :</h2>
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?= e($error); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($isAdmin): ?>
+        <section class="card software-card-form">
+            <h2>Ajouter un logiciel</h2>
+            <form action="<?= e($_SERVER['PHP_SELF']); ?>" method="post" enctype="multipart/form-data" class="software-form">
+                <input type="hidden" name="action" value="create">
+                <div class="form-grid">
+                    <div class="form-field">
+                        <label for="dm_type">Type de dispositif <span class="required">*</span></label>
+                        <select name="dm_type" id="dm_type" required>
+                            <option value="">-- Sélectionnez --</option>
+                            <?php foreach ($dmTypes as $type): ?>
+                                <option value="<?= e($type); ?>" <?= (isset($_POST['dm_type']) && $_POST['dm_type'] === $type) ? 'selected' : ''; ?>><?= e($type); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-field">
+                        <label for="dm_model">Modèle <span class="required">*</span></label>
+                        <select name="dm_model" id="dm_model" required>
+                            <option value="">-- Sélectionnez --</option>
+                            <?php
+                            $selectedType = $_POST['dm_type'] ?? '';
+                            $selectedModel = $_POST['dm_model'] ?? '';
+                            if (isset($catalogue[$selectedType])) {
+                                foreach ($catalogue[$selectedType] as $model) {
+                                    $isSelected = $selectedModel === $model ? 'selected' : '';
+                                    echo '<option value="' . e($model) . '" ' . $isSelected . '>' . e($model) . '</option>';
+                                }
+                            }
+                            ?>
+                        </select>
+                    </div>
+                    <div class="form-field">
+                        <label for="version">Version <span class="required">*</span></label>
+                        <input type="text" name="version" id="version" value="<?= e($_POST['version'] ?? ''); ?>" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="software_file">Fichier logiciel <span class="required">*</span></label>
+                        <input type="file" name="software_file" id="software_file" required>
+                    </div>
+                </div>
+                <div class="form-field">
+                    <label for="description">Description</label>
+                    <textarea name="description" id="description" rows="4" placeholder="Ajoutez des notes sur le logiciel (optionnel)"><?= e($_POST['description'] ?? ''); ?></textarea>
+                </div>
+                <button type="submit" class="button-link">Enregistrer le logiciel</button>
+            </form>
+        </section>
+    <?php endif; ?>
+
+    <section class="card">
+        <div class="software-filters">
+            <div class="filter-field">
+                <label for="filter-type">Type de dispositif</label>
+                <select id="filter-type">
+                    <option value="">Tous</option>
+                    <?php foreach ($dmTypes as $type): ?>
+                        <option value="<?= e($type); ?>"><?= e($type); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="filter-field">
+                <label for="filter-model">Modèle</label>
+                <select id="filter-model" disabled>
+                    <option value="">Tous</option>
+                </select>
+            </div>
+        </div>
+
+        <?php if (empty($softwareEntries)): ?>
+            <p class="empty-state">Aucun logiciel n'a encore été enregistré.</p>
+        <?php else: ?>
+            <div class="software-grid" data-catalogue='<?= e($catalogueJson); ?>'>
+                <?php foreach ($softwareEntries as $software): ?>
+                    <?php
+                    $softwareId = (int) ($software['id'] ?? 0);
+                    $downloadUrl = 'download_software.php?id=' . $softwareId;
+                    ?>
+                    <article class="software-card" data-type="<?= e($software['dm_type']); ?>" data-model="<?= e($software['dm_model']); ?>">
+                        <header class="software-card__header">
+                            <h3><?= e($software['dm_model']); ?></h3>
+                            <span class="software-card__type"><?= e($software['dm_type']); ?></span>
+                        </header>
+                        <dl class="software-card__meta">
+                            <div>
+                                <dt>Version</dt>
+                                <dd><?= e($software['version']); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Date d'ajout</dt>
+                                <dd><?= e(date('d/m/Y', strtotime($software['added_at']))); ?></dd>
+                            </div>
+                        </dl>
+                        <?php if (!empty($software['description'])): ?>
+                            <p class="software-card__description"><?= nl2br(e($software['description'])); ?></p>
+                        <?php endif; ?>
+                        <div class="software-card__actions">
+                            <a href="<?= e($downloadUrl); ?>" class="button-link">Télécharger</a>
+                            <?php if ($isAdmin): ?>
+                                <form method="post" action="<?= e($_SERVER['PHP_SELF']); ?>" onsubmit="return confirm('Supprimer ce logiciel ?');">
+                                    <input type="hidden" name="action" value="delete">
+                                    <input type="hidden" name="software_id" value="<?= e((string) $softwareId); ?>">
+                                    <button type="submit" class="button-link secondary">Supprimer</button>
+                                </form>
+                            <?php endif; ?>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+</main>
+
+<script>
+    (function () {
+        const gridElement = document.querySelector('.software-grid');
+        let catalogue = {};
+
+        if (gridElement && gridElement.dataset.catalogue) {
+            try {
+                catalogue = JSON.parse(gridElement.dataset.catalogue);
+            } catch (error) {
+                catalogue = {};
+            }
+        }
+
+        const typeSelect = document.getElementById('filter-type');
+        const modelSelect = document.getElementById('filter-model');
+        const cards = Array.from(document.querySelectorAll('.software-card'));
+
+        function populateModels(type) {
+            modelSelect.innerHTML = '<option value="">Tous</option>';
+            modelSelect.disabled = !type;
+
+            if (!type || !catalogue[type]) {
+                return;
+            }
+
+            catalogue[type].forEach(function (model) {
+                const option = document.createElement('option');
+                option.value = model;
+                option.textContent = model;
+                modelSelect.appendChild(option);
+            });
+        }
+
+        function filterCards() {
+            const selectedType = typeSelect.value;
+            const selectedModel = modelSelect.value;
+
+            cards.forEach(function (card) {
+                const matchesType = !selectedType || card.dataset.type === selectedType;
+                const matchesModel = !selectedModel || card.dataset.model === selectedModel;
+
+                card.style.display = (matchesType && matchesModel) ? '' : 'none';
+            });
+        }
+
+        if (typeSelect && modelSelect) {
+            typeSelect.addEventListener('change', function () {
+                populateModels(typeSelect.value);
+                modelSelect.value = '';
+                filterCards();
+            });
+
+            modelSelect.addEventListener('change', filterCards);
+        }
+
+        filterCards();
+    })();
+</script>
+</body>
+</html>

--- a/app1.0/partials/top_nav.php
+++ b/app1.0/partials/top_nav.php
@@ -13,6 +13,7 @@ if ($baseUrl === '') {
 
 $dashboardUrl = $baseUrl . '/tableau_de_bord.php';
 $backupsUrl = $baseUrl . '/index.php';
+$softwareUrl = $baseUrl . '/logiciels.php';
 $stockUrl = $baseUrl . '/gestion_stock/accueil.php';
 $logoutUrl = $baseUrl . '/logout.php';
 $logoPath = $baseUrl . '/gestion_stock/logo.png';
@@ -30,6 +31,7 @@ $isAdminUser = $currentRole === 'admin';
     <div class="top-nav__links">
         <a href="<?php echo htmlspecialchars($dashboardUrl, ENT_QUOTES, 'UTF-8'); ?>">Tableau de bord</a>
         <a href="<?php echo htmlspecialchars($backupsUrl, ENT_QUOTES, 'UTF-8'); ?>">Sauvegardes DM</a>
+        <a href="<?php echo htmlspecialchars($softwareUrl, ENT_QUOTES, 'UTF-8'); ?>">Logiciels DM</a>
         <a href="<?php echo htmlspecialchars($stockUrl, ENT_QUOTES, 'UTF-8'); ?>">Gestion de stock</a>
         <?php if ($isAdminUser): ?>
             <a href="<?php echo htmlspecialchars($usersUrl, ENT_QUOTES, 'UTF-8'); ?>">Utilisateurs</a>

--- a/app1.0/tableau_de_bord.php
+++ b/app1.0/tableau_de_bord.php
@@ -37,6 +37,11 @@ $isAdmin = $userRole === 'admin';
             <a class="button-link" href="index.php">Accéder aux sauvegardes</a>
         </article>
         <article class="portal-card">
+            <h2>Logiciels DM</h2>
+            <p>Mettez à disposition les logiciels officiels pour chaque dispositif médical et téléchargez-les dès que nécessaire.</p>
+            <a class="button-link" href="logiciels.php">Voir les logiciels</a>
+        </article>
+        <article class="portal-card">
             <h2>Gestion de stock</h2>
             <p>Consultez l'inventaire, ajoutez ou modifiez des pièces et administrez les utilisateurs autorisés. Toutes les actions respectent désormais la même identité visuelle.</p>
             <a class="button-link" href="gestion_stock/accueil.php">Accéder au stock</a>


### PR DESCRIPTION
## Summary
- add a device software management page that lets administrators upload packages by DM type and model and provides download links for users
- extend the database layer, configuration and documentation to cover the new device_software table and FTP software storage path
- refresh shared navigation, dashboard and styling to surface the new software module alongside existing backups features

## Testing
- php -l app1.0/logiciels.php
- php -l app1.0/download_software.php
- php -l app1.0/app/Database.php

------
https://chatgpt.com/codex/tasks/task_e_68d5163be468832aaf6b49be772064a9