### PR TITLE
Update DM models for catalogues

### DIFF
--- a/app1.0/gestion_stock/dashboard.php
+++ b/app1.0/gestion_stock/dashboard.php
@@ -542,9 +542,9 @@ a.back-home:hover {
   const currentLieu = <?= json_encode($currentLieu) ?>;
   document.addEventListener("DOMContentLoaded", function () {
     const famillesParGroupe = {
-      "Reprographe": ["DV5950", "DV5700", "DV6950"],
-      "Numériseur": ["CR VITA FLEX", "CR CLASSIC", "CR VITA"],
-      "Capteur plan": ["FOCUS", "DRX-1", "DRX PLUS"]
+      "Reprographe": ["DV5700", "DV5950", "DV6950"],
+      "Numériseur": ["CR CLASSIC", "CRVITA FLEX", "CR VITA"],
+      "Capteur plan": ["LUX", "FOCUS", "DRX"]
     };
 
     const references = <?= json_encode($references) ?>;
@@ -656,9 +656,9 @@ a.back-home:hover {
     }
 
     const famillesParGroupe = {
-      "Reprographe": ["DV5950", "DV5700", "DV6950"],
-      "Numériseur": ["CR VITA FLEX", "CR CLASSIC", "CR VITA"],
-      "Capteur plan": ["FOCUS", "DRX-1", "DRX PLUS"]
+      "Reprographe": ["DV5700", "DV5950", "DV6950"],
+      "Numériseur": ["CR CLASSIC", "CRVITA FLEX", "CR VITA"],
+      "Capteur plan": ["LUX", "FOCUS", "DRX"]
     };
 
     const groupeSelect = document.getElementById("groupe");

--- a/app1.0/logiciels.php
+++ b/app1.0/logiciels.php
@@ -21,9 +21,9 @@ $pdo = $db->pdo();
 $baseUrl = '.';
 
 $catalogue = [
-    'Numériseur' => ['CR CLASSIC', 'CR VITA', 'CR VITAFLEX'],
-    'Capteur' => ['LUX FOCUS', 'DRXPLUS'],
     'Reprograph' => ['DV5700', 'DV5950', 'DV6950'],
+    'Numériseur' => ['CR CLASSIC', 'CRVITA FLEX', 'CR VITA'],
+    'Capteur' => ['LUX', 'FOCUS', 'DRX'],
 ];
 
 $dmTypes = array_keys($catalogue);


### PR DESCRIPTION
## Summary
- align the DM catalogue with the requested model lists for reprograph, numériseur and capteur types
- update stock management dropdown mappings so each group now offers the new model options

## Testing
- php -l app1.0/logiciels.php
- php -l app1.0/gestion_stock/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d5289edfe4832aa643bfafb9524197